### PR TITLE
Add Jekyll PR preview workflow

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,0 +1,66 @@
+name: Jekyll PR Previews
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+  pull-requests: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    outputs:
+      pr_path: ${{ steps.setpath.outputs.pr_path }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@8aeb6ff8030dd539317f8e1769a044873b56ea71 # v1.268.0
+        with:
+          ruby-version: "3.2"
+          bundler-cache: true
+
+      # Determine output folder: main → root, PR → /pr-<number>/
+      - name: Determine output path
+        id: setpath
+        run: |
+          echo "pr_path=pr-${{ github.event.pull_request.number }}" >> $GITHUB_OUTPUT
+
+      # Build Jekyll
+      - name: Build Jekyll
+        run: |
+          DEST="./_site/${{ steps.setpath.outputs.pr_path }}"
+          mkdir -p "$DEST"
+          bundle exec jekyll build --destination "$DEST" --trace --baseurl "/pr-${{ github.event.pull_request.number }}/"
+
+      # Upload the artifact for deployment
+      - name: Upload Pages Artifact
+        uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b # v4.0.0
+        with:
+          path: _site
+
+  deploy:
+    runs-on: ubuntu-latest
+    needs: build
+
+    # Deploy for both PRs and main
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deploy
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5
+
+      # Comment PR preview URL
+      - name: Comment PR Preview URL
+        uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5.0.0
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          body: |
+            🔍 **Unique Jekyll PR Preview Ready**
+
+            Preview URL:  
+            **https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/pr-${{ github.event.pull_request.number }}/**


### PR DESCRIPTION
This workflow builds and deploys Jekyll previews for pull requests, including commenting the preview URL on the PR.